### PR TITLE
Fix binary alignment

### DIFF
--- a/config/tmhc.yaml
+++ b/config/tmhc.yaml
@@ -29,8 +29,8 @@ segments:
     start: 0x1000
     vram: 0x2100000
     bss_size: 0x3fbcf8
-    subalign: 1
-    align: 4
+    subalign: null
+    align: 1
     subsegments:
       # .text
       - [0x1000, asm, sdk/crt0]
@@ -496,14 +496,14 @@ segments:
       - [0x32bf00, databin] # .gcc_except_table
       - [0x32c080, databin] # .sdata
       # - [0xb54, sbss] # .sbss
-      - [0x32f6d4, databin] # .reginfo
-      - [0x3330b4, databin] # .DVP.overlay
-      - [0x338aec, databin] # .debug_str
-      - [0x339b38, databin] # .stab
-      - [0x353644, databin] # .stabstr
-      - [0x353774, databin] # .mdebug
-      - [0x3fbcf8, databin] # .bss
-      - [0x445360, databin] # .symtab
-      - [0x48c420, databin] # .strtab
-      - [0x4f670b, databin] # .shstrtab
+  - [0x32f6d4, databin] # .reginfo
+  - [0x3330b4, databin] # .DVP.overlay
+  - [0x338aec, databin] # .debug_str
+  - [0x339b38, databin] # .stab
+  - [0x353644, databin, section/stabstr] # .stabstr
+  - [0x353774, databin] # .mdebug
+  - [0x3fbcf8, databin] # .bss
+  - [0x445360, databin] # .symtab
+  - [0x48c420, databin, section/strtab] # .strtab
+  - [0x4f670b, databin, section/shstrtab] # .shstrtab
   - [0x4f71b4]

--- a/configure.py
+++ b/configure.py
@@ -97,7 +97,7 @@ def build_stuff(linker_entries: List[LinkerEntry]):
     ninja.rule(
         "as",
         description="as $in",
-        command=f"cpp {COMMON_INCLUDES} $in -o - | {cross}as -no-pad-sections -march=5900 -mabi=eabi -Iinclude -o $out",
+        command=f"cpp {COMMON_INCLUDES} $in -o - | {cross}as -no-pad-sections -march=5900 -mabi=eabi -Iinclude -o $out && python3 tools/elf_patcher.py $out gas $override",
     )
 
     ninja.rule(
@@ -139,16 +139,25 @@ def build_stuff(linker_entries: List[LinkerEntry]):
         if entry.object_path is None:
             continue
 
+        if entry.object_path.is_relative_to(Path("build/asm/sdk")):
+            override = "--section-align .text:0x4"
+        elif entry.object_path.is_relative_to(Path("build/asm/data/section")):
+            override = "--section-align .data:0x1"
+        elif entry.object_path.is_relative_to(Path("build/asm/data")):
+            override = "--section-align .data:0x4"
+        else:
+            override = ""
+
         if isinstance(seg, splat.segtypes.common.asm.CommonSegAsm) or isinstance(
             seg, splat.segtypes.common.data.CommonSegData
         ):
-            build(entry.object_path, entry.src_paths, "as")
+            build(entry.object_path, entry.src_paths, "as", variables={"override": override})
         elif isinstance(seg, splat.segtypes.common.cpp.CommonSegCpp):
             build(entry.object_path, entry.src_paths, "cpp")
         elif isinstance(seg, splat.segtypes.common.c.CommonSegC):
             build(entry.object_path, entry.src_paths, "cc")
         elif isinstance(seg, splat.segtypes.common.databin.CommonSegDatabin) or isinstance(seg, splat.segtypes.common.rodatabin.CommonSegRodatabin):
-            build(entry.object_path, entry.src_paths, "as")
+            build(entry.object_path, entry.src_paths, "as", variables={"override": override})
         else:
             print(f"ERROR: Unsupported build segment type {seg.type}")
             sys.exit(1)

--- a/tools/elf_patcher.py
+++ b/tools/elf_patcher.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2024 AngheloAlf
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import argparse
+import spimdisasm
+from pathlib import Path
+import struct
+
+def align_up(x: int, a: int) -> int:
+    return (x + (a-1)) & ~(a-1)
+
+SECTIONS_TO_REALIGN_PER_TOOL: dict[str, dict[str, int]] = {
+    "gas": {
+        ".text": 0x8,
+        ".data": 4,
+        ".rodata": 0x8,
+        ".ctor": 4,
+        ".init": 4,
+        ".exceptix": 4,
+        ".vtables": 0x10,
+        ".sdata": 4,
+        ".sbss": 4,
+        ".bss": 4,
+    },
+}
+
+spimdisasm.common.GlobalConfig.VERBOSE = False
+spimdisasm.common.GlobalConfig.QUIET = True
+
+parser = argparse.ArgumentParser(description="Patches elf objects to bypass alignment restrictions of other tools")
+
+parser.add_argument("elf_path")
+parser.add_argument("mode", choices=["gas"])
+parser.add_argument("--section-align", nargs="+")
+
+args = parser.parse_args()
+
+elf_path = Path(args.elf_path)
+section_align_override: dict[str, int] = {}
+if args.section_align is not None:
+    for entry in args.section_align:
+        sect, align_str = entry.split(":")
+        align = int(align_str, 0)
+        section_align_override[sect] = align
+
+elf_bytes = bytearray(elf_path.read_bytes())
+
+elf_file = spimdisasm.elf32.Elf32File(elf_bytes)
+
+sections_to_realign = SECTIONS_TO_REALIGN_PER_TOOL[args.mode]
+
+for i, sect in enumerate(elf_file.sectionHeaders):
+    name = elf_file.shstrtab[sect.name]
+    # print(name, sect)
+
+    # Check the cmd line override first
+    new_alignment = section_align_override.get(name)
+
+    if new_alignment is None:
+        # If no override is present then use the built-in ones
+        new_alignment = sections_to_realign.get(name)
+
+    if new_alignment is not None:
+        section_offset = elf_file.header.shoff + i * 0x28
+        addralign_pointer = section_offset + 0x20
+        size_pointer = section_offset + 0x14
+
+        # Patch the alignment of the section
+        fmt = spimdisasm.common.GlobalConfig.ENDIAN.toFormatString() + "I"
+        struct.pack_into(fmt, elf_bytes, addralign_pointer, new_alignment)
+
+        # new_size = align_up(sect.size, new_alignment)
+        # # Patch the size of the section
+        # fmt = spimdisasm.common.GlobalConfig.ENDIAN.toFormatString() + "I"
+        # struct.pack_into(fmt, elf_bytes, size_pointer, new_size)
+
+        # print(name)
+        # print(elf_bytes[section_offset:section_offset+0x28])
+
+elf_path.write_bytes(elf_bytes)


### PR DESCRIPTION
Adds elf_patcher.py which allows fixing alignment on sections of the binary which cannot be reconstructed with standard GCC/AS.